### PR TITLE
Implemented ability to mark functions as allowUnsafe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-throws",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "",
   "type": "module",
   "main": "index.js",

--- a/src/__tests__/throws.test.ts
+++ b/src/__tests__/throws.test.ts
@@ -203,4 +203,12 @@ describe('throws', () => {
         .catchSomeOtherError(() => {})
     }).toThrow()
   });
+
+  it('can run unsafe functions', () => {
+    const fn = createGetStringLengthFunction();
+    const getStringLength = throws(fn, { StringEmptyError }, { allowUnsafe: true });
+
+    expect(() => getStringLength.callUnsafe('')).toThrow(StringEmptyError)
+    expect(getStringLength.callUnsafe('hello')).toBe(5);
+  })
 })


### PR DESCRIPTION
This is probably dumb. But the idea came across my mind so I figured I'd put this out there.

```ts
const getStringLength = throws(fn, { StringEmptyError }, { allowUnsafe: true });

getStringLength.callUnsafe('') // throws like normal
getStringLength.callUnsafe('hello') // -> 5
```

If `allowUnsafe` is `false` (which is the default if no options are provided) then it doesn't add `callUnsafe` to the function. I just figured there may be edge cases where a developer might want to provide a way to bypass it