### PR TITLE
Allow classes that don't extend error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A tiny library that allows you to wrap functions with enforced error checking.
 ```ts
 import { throws } from 'ts-throws';
 
-class StringEmptyError extends Error {}
-class NoAsdfError extends Error {}
+class StringEmptyError {}
+class NoAsdfError {}
 
 const getStringLength = throws(
   (str: string) => {
@@ -61,7 +61,7 @@ It's plug-and-play:
 ```ts
 import { throws } from 'ts-throws';
 
-export class BadResponseError extends Error {}
+export class BadResponseError {}
 
 const getResponse = throws(
   async () => {
@@ -84,3 +84,10 @@ console.log(response); // -> Response
 ```
 
 Of course, if you don't catch the right errors you're still blocked from using the provided function.
+
+## Pitfalls
+
+- `class CustomError extends Error {}`
+
+  Extending `Error` causes a significant performance hit (~80%). If you don't need things like `Error.stack`, you probably
+  don't need to extend it anyway.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-throws",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "type": "module",
   "main": "index.js",

--- a/src/__tests__/performance.test.ts
+++ b/src/__tests__/performance.test.ts
@@ -98,10 +98,10 @@ describe('performance', () => {
       return state.runs;
     })();
 
-    console.table({
-      throwerRuns,
-      returnerRuns,
-      wrappedThrowerRuns
-    })
+    console.table([
+      { type: 'thrower', ['Runs per second']: throwerRuns.toLocaleString() },
+      { type: 'returner', ['Runs per second']: returnerRuns.toLocaleString() },
+      { type: 'thrower with ts-throws', ['Runs per second']: wrappedThrowerRuns.toLocaleString() },
+    ])
   });
 })

--- a/src/__tests__/performance.test.ts
+++ b/src/__tests__/performance.test.ts
@@ -1,11 +1,11 @@
 import {describe, it} from "vitest";
 import {throws} from "../index.js";
 
-class StringEmptyError extends Error {}
-class StringEmptyError2 extends Error {}
-class StringEmptyError3 extends Error {}
-class StringEmptyError4 extends Error {}
-class StringEmptyError5 extends Error {}
+class StringEmptyError {}
+class StringEmptyError2 {}
+class StringEmptyError3 {}
+class StringEmptyError4 {}
+class StringEmptyError5 {}
 
 const makeThrower = () => (str: string) => {
   const trimmed = str.trim();
@@ -98,9 +98,10 @@ describe('performance', () => {
       return state.runs;
     })();
 
-
-    console.log('Thrower runs per second', throwerRuns);
-    console.log('Returner runs per second', returnerRuns);
-    console.log('ts-throws wrapped runs per second', wrappedThrowerRuns);
+    console.table({
+      throwerRuns,
+      returnerRuns,
+      wrappedThrowerRuns
+    })
   });
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,8 @@ function createCatchEnforcer<
 
           return returnValue;
         } catch (err) {
+          // TODO: String error matchers
+          if (!err || typeof err !== 'object') throw err;
           return handleThrownError(err, state.catchers);
         }
       } else {
@@ -109,7 +111,7 @@ function createCatchEnforcer<
   return enforcer;
 }
 
-function handleThrownError(err: ErrorClass, catchers: Catcher<any>[]) {
+function handleThrownError(err: object, catchers: Catcher<any>[]) {
   const catcher = catchers.find(c => err instanceof c.errorClass);
 
   if (catcher) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-type ErrorClass = new (...args: any[]) => Error;
+type ErrorClass = new (...args: any[]) => {};
 
 export function throws<
   Args extends any[],
@@ -91,7 +91,6 @@ function createCatchEnforcer<
 
           return returnValue;
         } catch (err) {
-          if (!(err instanceof Error)) throw err;
           return handleThrownError(err, state.catchers);
         }
       } else {
@@ -110,7 +109,7 @@ function createCatchEnforcer<
   return enforcer;
 }
 
-function handleThrownError(err: Error, catchers: Catcher<any>[]) {
+function handleThrownError(err: ErrorClass, catchers: Catcher<any>[]) {
   const catcher = catchers.find(c => err instanceof c.errorClass);
 
   if (catcher) {


### PR DESCRIPTION
By allowing non error classes, performance can be improved:

```
┌─────────┬──────────────────────────┬─────────────────┐
│ (index) │ type                     │ Runs per second │
├─────────┼──────────────────────────┼─────────────────┤
│ 0       │ 'thrower'                │ '2,510,463'     │
│ 1       │ 'returner'               │ '16,148,904'    │
│ 2       │ 'thrower with ts-throws' │ '1,799,332'     │
└─────────┴──────────────────────────┴─────────────────┘
```

This is up from ~326k runs per second. By not instantiating `Error` classes, it can be ~5.5x faster
