### PR TITLE
Allow strings and regex to match errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,51 @@ console.log(response); // -> Response
 
 Of course, if you don't catch the right errors you're still blocked from using the provided function.
 
+## Usage without custom error classes
+
+You can provide regular expressions or strings to match thrown errors.
+
+```ts
+const getStringLength = throws(
+  (str: string) => {
+    if (!str.trim()) throw new Error('String is empty');
+    if (str === 'asdf') throw 'cannot be asdf';
+
+    return str.length;
+  },
+  { StringEmptyError: /is empty/, NoAsdfError: 'cannot be asdf' }
+);
+
+getStringLength(' ')
+  .catchStringEmptyError(err => {
+    // Note: `err` is going to be `unknown` in both of these cases.
+    console.error('String is empty')
+  })
+  .catchNoAsdfError(err => {
+    console.error('No asdf error')
+  });
+
+// -> Logs "String is empty"
+
+getStringLength('asdf')
+  .catchStringEmptyError(err => {
+    console.error('String is empty')
+  })
+  .catchNoAsdfError(err => {
+    console.error('No asdf error')
+  });
+
+// -> Logs "No asdf error"
+```
+
+When a string or regex is provided as the matcher, `ts-throws` will check the following:
+
+- `error.name`
+- `error.message`
+- The entire error if it's a string
+
+String matcher checks use `.include`, they are not converted to a `RegExp` before testing.
+
 ## Pitfalls
 
 - `class CustomError extends Error {}`

--- a/src/__tests__/throws.test.ts
+++ b/src/__tests__/throws.test.ts
@@ -130,6 +130,66 @@ describe('throws', () => {
     expect(caught).toBe(false);
   });
 
+  it('can match errors based on string', () => {
+    const fn = throws(() => {
+      throw new Error('message test')
+    }, { SomeError: 'message test' });
+
+    let caught = false;
+
+    fn()
+      .catchSomeError(err => {
+        caught = true;
+      })
+
+    class CustomError extends Error {
+      name = "hello"
+    }
+
+    const fn2 = throws(() => {
+      throw new CustomError()
+    }, { CustomError: 'hello' });
+
+    caught = false;
+
+    fn2()
+      .catchCustomError(err => {
+        caught = true;
+      })
+
+    expect(caught).toBe(true);
+  })
+
+  it('can match errors based on regex', () => {
+    const fn = throws(() => {
+      throw new Error('message test')
+    }, { SomeError: /test/ });
+
+    let caught = false;
+
+    fn()
+      .catchSomeError(err => {
+        caught = true;
+      })
+
+    class CustomError extends Error {
+      name = "hello"
+    }
+
+    const fn2 = throws(() => {
+      throw new CustomError()
+    }, { CustomError: /ello/ });
+
+    caught = false;
+
+    fn2()
+      .catchCustomError(err => {
+        caught = true;
+      })
+
+    expect(caught).toBe(true);
+  })
+
   it('can chain catches in any order', () => {
     let caught = false;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,21 +117,23 @@ function handleThrownError(err: object | string, catchers: Catcher<ErrorMatcher>
       return err instanceof c.errorMatcher;
     }
 
-    const regex = c.errorMatcher instanceof RegExp ? c.errorMatcher : new RegExp(c.errorMatcher);
+    const matcher = c.errorMatcher instanceof RegExp ? c.errorMatcher : {
+      test: (str: string) => str.includes(c.errorMatcher as string)
+    };
 
     if (typeof err === 'string') {
-      return regex.test(err);
+      return matcher.test(err);
     }
 
     if (typeof err === 'object') {
       if ('name' in err && typeof err.name === 'string') {
-        const nameMatches = regex.test(err.name);
+        const nameMatches = matcher.test(err.name);
 
         if (nameMatches) return true;
       }
 
       if ('message' in err && typeof err.message === 'string') {
-        const messageMatches = regex.test(err.message);
+        const messageMatches = matcher.test(err.message);
 
         if (messageMatches) return true;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,14 +86,14 @@ function createCatchEnforcer<
           if (returnValue instanceof Promise) {
             return returnValue
               .catch(err => {
-                return handleThrownError(err, state.catchers);
+                return invokeMatchedErrorCatcher(err, state.catchers);
               })
           }
 
           return returnValue;
         } catch (err) {
           if (!err) throw err;
-          return handleThrownError(err, state.catchers);
+          return invokeMatchedErrorCatcher(err, state.catchers);
         }
       } else {
         return catchObj;
@@ -111,7 +111,7 @@ function createCatchEnforcer<
   return enforcer;
 }
 
-function handleThrownError(err: object | string, catchers: Catcher<ErrorMatcher>[]) {
+function invokeMatchedErrorCatcher(err: object | string, catchers: Catcher<ErrorMatcher>[]) {
   const catcher = catchers.find(c => {
     if (typeof c.errorMatcher === 'function') {
       return err instanceof c.errorMatcher;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 type ErrorClass = new (...args: any[]) => {};
+type ErrorMatcher = ErrorClass | string | RegExp;
 
 export function throws<
   Args extends any[],
   Return,
-  const E extends { [key in string]: ErrorClass }
+  const E extends { [key in string]: ErrorMatcher }
 >(
   fn: (...args: Args) => Return,
   errors: E
@@ -14,19 +15,19 @@ export function throws<
 type UnwrapPromise<T extends Promise<unknown>> = T extends Promise<infer V> ? V : never;
 
 type CatchEnforcer<
-  E extends Record<string, ErrorClass>,
+  E extends Record<string, ErrorMatcher>,
   T
 > = {
   [K in keyof E as `catch${Capitalize<string & K>}`]: <const _E extends E[K]>(
-    cb: (e: InstanceType<_E>) => void
+    cb: (e: _E extends ErrorClass ? InstanceType<_E> : unknown) => void
   ) => Omit<E, K> extends Record<string, never>
     ? T extends Promise<unknown> ? Promise<UnwrapPromise<T> | undefined> : undefined
     : CatchEnforcer<Omit<E, K>, T>;
 };
 
-type Catcher<E extends ErrorClass> = {
-  errorClass: E;
-  cb: (e: InstanceType<E>) => void;
+type Catcher<E extends ErrorMatcher> = {
+  errorMatcher: E;
+  cb: (e: E extends ErrorClass ? InstanceType<E> : unknown) => void;
 };
 
 type CachedEnforcerState = {
@@ -41,7 +42,7 @@ const cachedEnforcer = Symbol('cachedEnforcer');
 function createCatchEnforcer<
   A extends any[],
   T,
-  const E extends { [key in string]: ErrorClass }
+  const E extends { [key in string]: ErrorMatcher }
 >(
   fn: FnWithState<(...args: A) => T>,
   args: A,
@@ -61,20 +62,20 @@ function createCatchEnforcer<
     const catchKey = `catch${capitalize(errorName)}` as keyof CatchEnforcer<E, T>;
 
     catchObj[catchKey] = (<const _E extends E[typeof errorName]>(
-      cb: (error: InstanceType<_E>) => void
+      cb: (error: _E extends ErrorClass ? InstanceType<_E> : unknown) => void
     ) => {
       const state = fn[cachedEnforcer];
       if (!state) throw new Error('[ts-throws] Expected function to have enforcer state, please open an issue');
 
       const catchers = state.catchers;
-      const errorClass = errors[errorName];
+      const errorMatcher = errors[errorName];
 
-      if (catchers.some(({ errorClass: e }) => e === errorClass)) {
-        console.error('[ts-throws] Error already handled:', errorClass);
+      if (catchers.some(({ errorMatcher: e }) => e === errorMatcher)) {
+        console.error('[ts-throws] Error already handled:', errorMatcher);
         throw new Error(`[ts-throws] Duplicate error catch functions are not allowed`);
       }
 
-      catchers.push({ errorClass, cb });
+      catchers.push({ errorMatcher, cb });
 
       if (catchers.length === errorNames.length) {
         // should attempt to return original function value
@@ -91,8 +92,7 @@ function createCatchEnforcer<
 
           return returnValue;
         } catch (err) {
-          // TODO: String error matchers
-          if (!err || typeof err !== 'object') throw err;
+          if (!err) throw err;
           return handleThrownError(err, state.catchers);
         }
       } else {
@@ -111,8 +111,34 @@ function createCatchEnforcer<
   return enforcer;
 }
 
-function handleThrownError(err: object, catchers: Catcher<any>[]) {
-  const catcher = catchers.find(c => err instanceof c.errorClass);
+function handleThrownError(err: object | string, catchers: Catcher<ErrorMatcher>[]) {
+  const catcher = catchers.find(c => {
+    if (typeof c.errorMatcher === 'function') {
+      return err instanceof c.errorMatcher;
+    }
+
+    const regex = c.errorMatcher instanceof RegExp ? c.errorMatcher : new RegExp(c.errorMatcher);
+
+    if (typeof err === 'string') {
+      return regex.test(err);
+    }
+
+    if (typeof err === 'object') {
+      if ('name' in err && typeof err.name === 'string') {
+        const nameMatches = regex.test(err.name);
+
+        if (nameMatches) return true;
+      }
+
+      if ('message' in err && typeof err.message === 'string') {
+        const messageMatches = regex.test(err.message);
+
+        if (messageMatches) return true;
+      }
+    }
+
+    return false;
+  });
 
   if (catcher) {
     // We tested err instance above


### PR DESCRIPTION
This can help for wrapping third-party functions where the error classes aren't known, or custom error classes aren't used and assertions need to be made against the `name` / `message` of an `Error`, or the contents of the error if a string is thrown.