### PR TITLE
Add support for functions that return errors instead of throwing, see #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,55 @@ When a string or regex is provided as the matcher, `ts-throws` will check the fo
 
 String matcher checks use `.include`, they are not converted to a `RegExp` before testing.
 
+## Functions that return errors instead of throwing
+
+`ts-throws` handles this by trying to match the return value against each provided error.
+
+```ts
+const getStringLength = throws(
+  (str: string) => {
+    if (!str.trim()) return new Error('String is empty');
+    if (str === 'asdf') return 'cannot be asdf';
+
+    return str.length;
+  },
+  { StringEmptyError: /is empty/, NoAsdfError: 'cannot be asdf' }
+);
+
+getStringLength(' ')
+  .catchStringEmptyError(err => {
+    // Note: `err` is going to be `unknown` in both of these cases.
+    console.error('String is empty')
+  })
+  .catchNoAsdfError(err => {
+    console.error('No asdf error')
+  });
+
+// -> Logs "String is empty"
+
+getStringLength('asdf')
+  .catchStringEmptyError(err => {
+    console.error('String is empty')
+  })
+  .catchNoAsdfError(err => {
+    console.error('No asdf error')
+  });
+
+// -> Logs "No asdf error"
+
+const length = getStringLength('hello')
+  .catchStringEmptyError(err => {
+    console.error('String is empty')
+  })
+  .catchNoAsdfError(err => {
+    console.error('No asdf error')
+  });
+
+// `length` is 5
+```
+
+Of course, this works with custom error classes as well.
+
 ## Pitfalls
 
 - `class CustomError extends Error {}`

--- a/src/__tests__/performance.test.ts
+++ b/src/__tests__/performance.test.ts
@@ -34,11 +34,41 @@ const makeWrappedThrower = () => throws((str: string) => {
   StringEmptyError5
 });
 
+const makeWrappedReturner = () => throws((str: string) => {
+  const trimmed = str.trim();
+  if (trimmed.length === 0) return new StringEmptyError();
+
+  return trimmed.length;
+}, {
+  StringEmptyError,
+  StringEmptyError2,
+  StringEmptyError3,
+  StringEmptyError4,
+  StringEmptyError5
+});
+
+const makeSafeFn = () => (str: string) => {
+  const trimmed = str.trim();
+  return trimmed.length;
+};
+
+const makeWrappedSafeFn = () => throws((str: string) => {
+  const trimmed = str.trim();
+  return trimmed.length;
+}, {
+  StringEmptyError,
+  StringEmptyError2,
+  StringEmptyError3,
+  StringEmptyError4,
+  StringEmptyError5
+});
+
 describe('performance', () => {
-  it('works in an ideal scenario', async () => {
+  it('benchmarks with errors', async () => {
     const getStrLenThrower = makeThrower();
     const getStrLenReturner = makeReturner();
     const getStrLenWrappedThrower = makeWrappedThrower();
+    const getStrLenWrappedReturner = makeWrappedReturner();
 
     const throwerRuns = (() => {
       const state = { done: false, runs: 0 };
@@ -98,10 +128,81 @@ describe('performance', () => {
       return state.runs;
     })();
 
+    const wrappedReturnerRuns = (() => {
+      const state = { done: false, runs: 0 };
+      const before = performance.now();
+
+      while (!state.done) {
+        getStrLenWrappedReturner('')
+          .catchStringEmptyError(err => {
+            state.runs++;
+          })
+          .catchStringEmptyError2(() => {})
+          .catchStringEmptyError3(() => {})
+          .catchStringEmptyError4(() => {})
+          .catchStringEmptyError5(() => {})
+
+        const diff = performance.now() - before;
+        if (diff >= 1000) state.done = true;
+      }
+
+      return state.runs;
+    })();
+
     console.table([
       { type: 'thrower', ['Runs per second']: throwerRuns.toLocaleString() },
       { type: 'returner', ['Runs per second']: returnerRuns.toLocaleString() },
       { type: 'thrower with ts-throws', ['Runs per second']: wrappedThrowerRuns.toLocaleString() },
+      { type: 'returner with ts-throws', ['Runs per second']: wrappedReturnerRuns.toLocaleString() },
     ])
   });
+
+  /*
+    Compares direct overhead when a function does not produce any errors.
+  */
+  it('benchmark without errors', () => {
+    const safeFn = makeSafeFn();
+    const wrappedSafeFn = makeWrappedSafeFn();
+
+    const safeFnRuns = (() => {
+      const state = { done: false, runs: 0 };
+      const before = performance.now();
+
+      while (!state.done) {
+        safeFn('');
+        state.runs++;
+
+        const diff = performance.now() - before;
+        if (diff >= 1000) state.done = true;
+      }
+
+      return state.runs;
+    })();
+
+    const wrappedSafeFnRuns = (() => {
+      const state = { done: false, runs: 0 };
+      const before = performance.now();
+
+      while (!state.done) {
+        wrappedSafeFn('')
+          .catchStringEmptyError(() => {})
+          .catchStringEmptyError2(() => {})
+          .catchStringEmptyError3(() => {})
+          .catchStringEmptyError4(() => {})
+          .catchStringEmptyError5(() => {});
+
+        state.runs++;
+
+        const diff = performance.now() - before;
+        if (diff >= 1000) state.done = true;
+      }
+
+      return state.runs;
+    })();
+
+    console.table([
+      { type: 'safe', ['Runs per second']: safeFnRuns.toLocaleString() },
+      { type: 'safe with ts-throws', ['Runs per second']: wrappedSafeFnRuns.toLocaleString() },
+    ])
+  })
 })

--- a/src/__tests__/throws.test.ts
+++ b/src/__tests__/throws.test.ts
@@ -109,6 +109,21 @@ describe('throws', () => {
     expect(caught).toBe(true);
   })
 
+  it('handles errors in return value', () => {
+    let caught = false;
+
+    const fn = throws(() => {
+      return new StringEmptyError();
+    }, { StringEmptyError })
+
+    fn()
+      .catchStringEmptyError(err => {
+        caught = true;
+      });
+
+    expect(caught).toBe(true);
+  });
+
   it('works with multiple errors', () => {
     let caught = false;
 


### PR DESCRIPTION
I'm a little bit skeptical as it impacts performance quite a bit:

```
stdout | src/__tests__/performance.test.ts > performance > benchmarks with errors
┌─────────┬───────────────────────────┬─────────────────┐
│ (index) │ type                      │ Runs per second │
├─────────┼───────────────────────────┼─────────────────┤
│ 0       │ 'thrower'                 │ '2,488,717'     │
│ 1       │ 'returner'                │ '16,151,812'    │
│ 2       │ 'thrower with ts-throws'  │ '1,811,761'     │
│ 3       │ 'returner with ts-throws' │ '3,350,197'     │
└─────────┴───────────────────────────┴─────────────────┘

stdout | src/__tests__/performance.test.ts > performance > benchmark without errors
┌─────────┬───────────────────────┬─────────────────┐
│ (index) │ type                  │ Runs per second │
├─────────┼───────────────────────┼─────────────────┤
│ 0       │ 'safe'                │ '16,838,949'    │
│ 1       │ 'safe with ts-throws' │ '2,112,413'     │
└─────────┴───────────────────────┴─────────────────┘
```

The problem here is we always check the return value for errors even if it's not applicable. Perhaps we should consider some `throws` options, or some other way of opting into this
